### PR TITLE
Updated Spark versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,10 +113,10 @@ MAINTAINER irm
 WORKDIR /root
 
 # install Spark
-RUN wget http://apache.rediris.es/spark/spark-2.4.2/spark-2.4.2-bin-hadoop2.7.tgz && \
-    tar -xvf spark-2.4.0-bin-hadoop2.7.tgz && \
-    mv spark-2.4.0-bin-hadoop2.7 /usr/local/spark && \
-    rm spark-2.4.0-bin-hadoop2.7.tgz
+RUN wget http://apache.rediris.es/spark/spark-2.4.4/spark-2.4.4-bin-hadoop2.7.tgz && \
+    tar -xvf spark-2.4.4-bin-hadoop2.7.tgz && \
+    mv spark-2.4.4-bin-hadoop2.7 /usr/local/spark && \
+    rm spark-2.4.4-bin-hadoop2.7.tgz
 
 ENV PATH=$PATH:/usr/local/spark/bin
 ENV SPARK_HOME=/usr/local/spark

--- a/docker/master/Dockerfile
+++ b/docker/master/Dockerfile
@@ -4,10 +4,10 @@ MAINTAINER irm
 WORKDIR /root
 
 # install Spark
-RUN wget http://apache.rediris.es/spark/spark-2.4.2/spark-2.4.2-bin-hadoop2.7.tgz && \
-    tar -xvf spark-2.4.2-bin-hadoop2.7.tgz && \
-    mv spark-2.4.2-bin-hadoop2.7 /usr/local/spark && \
-    rm spark-2.4.2-bin-hadoop2.7.tgz
+RUN wget http://apache.rediris.es/spark/spark-2.4.4/spark-2.4.4-bin-hadoop2.7.tgz && \
+    tar -xvf spark-2.4.4-bin-hadoop2.7.tgz && \
+    mv spark-2.4.4-bin-hadoop2.7 /usr/local/spark && \
+    rm spark-2.4.4-bin-hadoop2.7.tgz
 
 ENV PATH=$PATH:/usr/local/spark/bin
 ENV SPARK_HOME=/usr/local/spark


### PR DESCRIPTION
Hi Ivan. Spark 2.2 was removed from RedIRIS repo and the master node deployment was failing. Updated to 2.4. Btw, thanks for these great scripts!